### PR TITLE
re-export ahash for version matching

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod code_table;
 pub mod code_table_type;
+pub use ahash;
 use ahash::AHashMap;
 use std::borrow::Cow;
 use std::convert::Into;


### PR DESCRIPTION
Since `rustc` can't tell if the version of `ahash::AHashMap` used by this crate differs from the version used by a client, republish `ahash`.