### PR TITLE
Add public alias type for AHashMap

### DIFF
--- a/generate_table.py
+++ b/generate_table.py
@@ -21,8 +21,8 @@ def print_header(timestamp: str, f: TextIOBase = stdout):
         f"""\
 //! Code table
 //! Generated at {timestamp}
+use super::OEMCPHashMap;
 use super::code_table_type::TableType;
-use ahash::AHashMap;
 use lazy_static::lazy_static;
 use TableType::*;""",
         file=f,
@@ -71,8 +71,8 @@ lazy_static! {""",
         print(
             f"    /// Encoding table (Unicode to CP{codepage})\n"
             f"    pub static ref ENCODING_TABLE_CP{codepage}"
-            ": AHashMap<char, u8> = {\n"
-            "        let mut m = AHashMap::new();",
+            ": OEMCPHashMap<char, u8> = {\n"
+            "        let mut m = OEMCPHashMap::new();",
             file=f,
         )
         for unicode, dest in m.items():
@@ -121,8 +121,8 @@ lazy_static! {
     ///     panic!("CP874 must be defined in DECODING_TABLE_CP_MAP");
     /// }
     /// ```
-    pub static ref DECODING_TABLE_CP_MAP: AHashMap<u16, TableType> = {
-        let mut map = AHashMap::new();""",
+    pub static ref DECODING_TABLE_CP_MAP: OEMCPHashMap<u16, TableType> = {
+        let mut map = OEMCPHashMap::new();""",
         file=f,
     )
     for (codepage, table) in table_map.items():
@@ -163,8 +163,8 @@ lazy_static! {
     ///     panic!("CP437 must be registerd in ENCODING_TABLE_CP_MAP");
     /// }
     /// ```
-    pub static ref ENCODING_TABLE_CP_MAP: AHashMap<u16, &'static AHashMap<char, u8>> = {
-        let mut m = AHashMap::new();""",
+    pub static ref ENCODING_TABLE_CP_MAP: OEMCPHashMap<u16, &'static OEMCPHashMap<char, u8>> = {
+        let mut m = OEMCPHashMap::new();""",
         file=f,
     )
     for codepage, m in reverse_map.items():

--- a/src/code_table.rs
+++ b/src/code_table.rs
@@ -1,7 +1,7 @@
 //! Code table
 //! Generated at 2020-09-22T01:23:23+00:00
+use super::OEMCPHashMap;
 use super::code_table_type::TableType;
-use ahash::AHashMap;
 use lazy_static::lazy_static;
 use TableType::*;
 /// Decoding table (CP437 to Unicode)
@@ -908,8 +908,8 @@ pub static DECODING_TABLE_CP874: [Option<char>; 128] = [
 ];
 lazy_static! {
     /// Encoding table (Unicode to CP437)
-    pub static ref ENCODING_TABLE_CP437: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP437: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{00C7}', 0x80);
         m.insert('\u{00FC}', 0x81);
         m.insert('\u{00E9}', 0x82);
@@ -1041,8 +1041,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP737)
-    pub static ref ENCODING_TABLE_CP737: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP737: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{0391}', 0x80);
         m.insert('\u{0392}', 0x81);
         m.insert('\u{0393}', 0x82);
@@ -1174,8 +1174,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP775)
-    pub static ref ENCODING_TABLE_CP775: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP775: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{0106}', 0x80);
         m.insert('\u{00FC}', 0x81);
         m.insert('\u{00E9}', 0x82);
@@ -1307,8 +1307,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP850)
-    pub static ref ENCODING_TABLE_CP850: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP850: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{00C7}', 0x80);
         m.insert('\u{00FC}', 0x81);
         m.insert('\u{00E9}', 0x82);
@@ -1440,8 +1440,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP852)
-    pub static ref ENCODING_TABLE_CP852: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP852: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{00C7}', 0x80);
         m.insert('\u{00FC}', 0x81);
         m.insert('\u{00E9}', 0x82);
@@ -1573,8 +1573,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP855)
-    pub static ref ENCODING_TABLE_CP855: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP855: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{0452}', 0x80);
         m.insert('\u{0402}', 0x81);
         m.insert('\u{0453}', 0x82);
@@ -1706,8 +1706,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP857)
-    pub static ref ENCODING_TABLE_CP857: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP857: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{00C7}', 0x80);
         m.insert('\u{00FC}', 0x81);
         m.insert('\u{00E9}', 0x82);
@@ -1836,8 +1836,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP860)
-    pub static ref ENCODING_TABLE_CP860: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP860: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{00C7}', 0x80);
         m.insert('\u{00FC}', 0x81);
         m.insert('\u{00E9}', 0x82);
@@ -1969,8 +1969,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP861)
-    pub static ref ENCODING_TABLE_CP861: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP861: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{00C7}', 0x80);
         m.insert('\u{00FC}', 0x81);
         m.insert('\u{00E9}', 0x82);
@@ -2102,8 +2102,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP862)
-    pub static ref ENCODING_TABLE_CP862: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP862: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{05D0}', 0x80);
         m.insert('\u{05D1}', 0x81);
         m.insert('\u{05D2}', 0x82);
@@ -2235,8 +2235,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP863)
-    pub static ref ENCODING_TABLE_CP863: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP863: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{00C7}', 0x80);
         m.insert('\u{00FC}', 0x81);
         m.insert('\u{00E9}', 0x82);
@@ -2368,8 +2368,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP864)
-    pub static ref ENCODING_TABLE_CP864: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP864: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{066A}', 0x25);
         m.insert('\u{00B0}', 0x80);
         m.insert('\u{00B7}', 0x81);
@@ -2496,8 +2496,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP865)
-    pub static ref ENCODING_TABLE_CP865: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP865: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{00C7}', 0x80);
         m.insert('\u{00FC}', 0x81);
         m.insert('\u{00E9}', 0x82);
@@ -2629,8 +2629,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP866)
-    pub static ref ENCODING_TABLE_CP866: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP866: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{0410}', 0x80);
         m.insert('\u{0411}', 0x81);
         m.insert('\u{0412}', 0x82);
@@ -2762,8 +2762,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP869)
-    pub static ref ENCODING_TABLE_CP869: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP869: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{0386}', 0x86);
         m.insert('\u{00B7}', 0x88);
         m.insert('\u{00AC}', 0x89);
@@ -2886,8 +2886,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP720)
-    pub static ref ENCODING_TABLE_CP720: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP720: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{001C}', 0x1A);
         m.insert('\u{007F}', 0x1C);
         m.insert('\u{001A}', 0x7F);
@@ -3014,8 +3014,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP858)
-    pub static ref ENCODING_TABLE_CP858: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP858: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{001C}', 0x1A);
         m.insert('\u{007F}', 0x1C);
         m.insert('\u{001A}', 0x7F);
@@ -3150,8 +3150,8 @@ lazy_static! {
         return m;
     };
     /// Encoding table (Unicode to CP874)
-    pub static ref ENCODING_TABLE_CP874: AHashMap<char, u8> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP874: OEMCPHashMap<char, u8> = {
+        let mut m = OEMCPHashMap::new();
         m.insert('\u{20AC}', 0x80);
         m.insert('\u{0081}', 0x81);
         m.insert('\u{0082}', 0x82);
@@ -3301,8 +3301,8 @@ lazy_static! {
     ///     panic!("CP874 must be defined in DECODING_TABLE_CP_MAP");
     /// }
     /// ```
-    pub static ref DECODING_TABLE_CP_MAP: AHashMap<u16, TableType> = {
-        let mut map = AHashMap::new();
+    pub static ref DECODING_TABLE_CP_MAP: OEMCPHashMap<u16, TableType> = {
+        let mut map = OEMCPHashMap::new();
         map.insert(437, Complete(&DECODING_TABLE_CP437));
         map.insert(737, Complete(&DECODING_TABLE_CP737));
         map.insert(775, Complete(&DECODING_TABLE_CP775));
@@ -3343,8 +3343,8 @@ lazy_static! {
     ///     panic!("CP437 must be registerd in ENCODING_TABLE_CP_MAP");
     /// }
     /// ```
-    pub static ref ENCODING_TABLE_CP_MAP: AHashMap<u16, &'static AHashMap<char, u8>> = {
-        let mut m = AHashMap::new();
+    pub static ref ENCODING_TABLE_CP_MAP: OEMCPHashMap<u16, &'static OEMCPHashMap<char, u8>> = {
+        let mut m = OEMCPHashMap::new();
         m.insert(437, &*ENCODING_TABLE_CP437);
         m.insert(737, &*ENCODING_TABLE_CP737);
         m.insert(775, &*ENCODING_TABLE_CP775);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,14 @@
 pub mod code_table;
 pub mod code_table_type;
 use ahash::AHashMap;
+/// The type of hashmap used in this crate.
+///
+/// The hash library may be changed in the future release.
+/// Make sure to use only APIs compatible with `std::collections::HashMap`.
+pub type OEMCPHashMap<K, V> = AHashMap<K, V>;
 use std::borrow::Cow;
 use std::convert::Into;
+
 
 /// Decode SBCS (single byte character set) bytes (no undefined codepoints)
 ///
@@ -128,7 +134,7 @@ pub fn decode_string_incomplete_table_lossy<'a, T: Into<Cow<'a, [u8]>>>(
 /// ```
 pub fn encode_string_checked<'a, T: Into<Cow<'a, str>>>(
     src: T,
-    encoding_table: &AHashMap<char, u8>,
+    encoding_table: &OEMCPHashMap<char, u8>,
 ) -> Option<Vec<u8>> {
     let mut ret = Vec::new();
     for c in src.into().chars() {
@@ -164,7 +170,7 @@ pub fn encode_string_checked<'a, T: Into<Cow<'a, str>>>(
 /// ```
 pub fn encode_string_lossy<'a, T: Into<Cow<'a, str>>>(
     src: T,
-    encoding_table: &AHashMap<char, u8>,
+    encoding_table: &OEMCPHashMap<char, u8>,
 ) -> Vec<u8> {
     src.into()
         .chars()


### PR DESCRIPTION
Concept based on #2
Close #3

```rust
use oem_cp::OEMCPHashMap;

const encode_table: &'static OEMCPHashMap<char, u8>
    = *(*oem_cp::code_table::ENCODING_TABLE_CP_MAP).get(&437).unwrap();
```