### PR TITLE
added debug and clone to TableType

### DIFF
--- a/src/code_table_type.rs
+++ b/src/code_table_type.rs
@@ -8,6 +8,7 @@ use std::convert::Into;
 /// Wrapper enumerate for decoding tables
 ///
 /// It has 2 types: `Complete`, complete tables (it doesn't have undefined codepoints) / `Incomplete`, incomplete tables (does have ones)
+#[derive(Debug, Clone)]
 pub enum TableType {
     /// complete table, which doen't have any undefined codepoints
     Complete(&'static [char; 128]),


### PR DESCRIPTION
This one-liner makes `TableType` be `Debug` and `Clone`. Closes Issue #5.